### PR TITLE
Item history

### DIFF
--- a/ui/src/main/java/de/ipb_halle/lbac/items/bean/ItemState.java
+++ b/ui/src/main/java/de/ipb_halle/lbac/items/bean/ItemState.java
@@ -119,8 +119,25 @@ public class ItemState {
         return dates.get(index + 1);
     }
 
-    // TODO: does not work this way
+    /**
+     * @return true if the currently selected item version is the latest revision.
+     */
+    public boolean isLastHistoryItem() {
+        return currentHistoryDate == null;
+    }
+
+    /**
+     * @return true if the currently selected item version is the first revision.
+     */
     public boolean isStartingHistoryItem() {
+        // TODO: does not work this way
         return getPreviousKey(currentHistoryDate) == null;
+    }
+
+    /**
+     * @return date when this revision was done
+     */
+    public Date getChangeDate() {
+        return getPreviousKey(currentHistoryDate);
     }
 }

--- a/ui/src/main/java/de/ipb_halle/lbac/items/bean/ItemState.java
+++ b/ui/src/main/java/de/ipb_halle/lbac/items/bean/ItemState.java
@@ -64,7 +64,7 @@ public class ItemState {
         copiedItem.setHistory(original.getHistory());
         copiedItem.setACList(original.getACList());
         copiedItem.setOwner(original.getOwner());
-                
+
         return copiedItem;
     }
 
@@ -90,52 +90,60 @@ public class ItemState {
 
     public Date getPreviousKey(Date d) {
         if (d == null) {
-            if(editedItem.getHistory().isEmpty() ){
+            if (editedItem.getHistory().isEmpty()) {
                 return null;
-            }else{
-                return editedItem.getHistory().lastKey();    
+            } else {
+                return editedItem.getHistory().lastKey();
             }
-            
+
         }
-        if (editedItem.getHistory().isEmpty() || !editedItem.getHistory().containsKey(d)) {
+        if (editedItem.getHistory().isEmpty()
+                || !editedItem.getHistory().containsKey(d)) {
             return null;
         }
         if (editedItem.getHistory().firstKey().equals(d)) {
             return null;
         }
-        ArrayList<Date> dates = new ArrayList<>(editedItem.getHistory().keySet());
+        ArrayList<Date> dates = new ArrayList<>(
+                editedItem.getHistory().keySet());
 
         int index = dates.indexOf(d);
 
         return dates.get(index - 1);
     }
-    
-      public Date getFollowingKey(Date d) {
-        if (d == null||editedItem.getHistory().isEmpty()||d.getTime()==editedItem.getHistory().lastKey().getTime()) {
+
+    public Date getFollowingKey(Date d) {
+        if (d == null || editedItem.getHistory().isEmpty()
+                || d.getTime() == editedItem.getHistory().lastKey().getTime()) {
             return null;
         }
-        ArrayList<Date> dates = new ArrayList<>(editedItem.getHistory().keySet());
+        ArrayList<Date> dates = new ArrayList<>(
+                editedItem.getHistory().keySet());
         int index = dates.indexOf(d);
         return dates.get(index + 1);
     }
 
     /**
-     * @return true if the currently selected item version is the latest revision.
+     * @return true if the currently selected item version is the latest
+     *         revision.
      */
     public boolean isLastHistoryItem() {
-        return currentHistoryDate == null;
+        return editedItem.getHistory().isEmpty() || currentHistoryDate == null;
     }
 
     /**
-     * @return true if the currently selected item version is the first revision.
+     * @return true if the currently selected item version is the original item.
      */
     public boolean isStartingHistoryItem() {
-        // TODO: does not work this way
-        return getPreviousKey(currentHistoryDate) == null;
+        if (editedItem.getHistory().isEmpty()) {
+            return true;
+        }
+        return editedItem.getHistory().firstKey().equals(currentHistoryDate);
     }
 
     /**
-     * @return date when this revision was done
+     * @return date when this revision was done, null if this revision is the
+     *         original item
      */
     public Date getChangeDate() {
         return getPreviousKey(currentHistoryDate);

--- a/ui/src/main/java/de/ipb_halle/lbac/items/bean/history/HistoryOperation.java
+++ b/ui/src/main/java/de/ipb_halle/lbac/items/bean/history/HistoryOperation.java
@@ -46,28 +46,32 @@ public class HistoryOperation {
     }
 
     public void applyNextNegativeDifference() {
-        itemState.setCurrentHistoryDate(itemState.getPreviousKey(itemState.getCurrentHistoryDate()));
+        if (!itemState.isStartingHistoryItem()) {
+            itemState.setCurrentHistoryDate(itemState.getPreviousKey(itemState.getCurrentHistoryDate()));
 
-        for (ItemDifference diff : orderDifferences(itemState.getEditedItem().getHistory().get(itemState.getCurrentHistoryDate()))) {
-            if (diff instanceof ItemHistory) {
-                applyNegativeItemHistory((ItemHistory) diff);
-            }
-            if (diff instanceof ItemPositionHistoryList) {
-                applyNegativePositionDiff((ItemPositionHistoryList) diff);
+            for (ItemDifference diff : orderDifferences(itemState.getEditedItem().getHistory().get(itemState.getCurrentHistoryDate()))) {
+                if (diff instanceof ItemHistory) {
+                    applyNegativeItemHistory((ItemHistory) diff);
+                }
+                if (diff instanceof ItemPositionHistoryList) {
+                    applyNegativePositionDiff((ItemPositionHistoryList) diff);
+                }
             }
         }
     }
 
     public void applyNextPositiveDifference() {
-        for (ItemDifference diff : orderDifferences(itemState.getEditedItem().getHistory().get(itemState.getCurrentHistoryDate()))) {
-            if (diff instanceof ItemHistory) {
-                applyPositiveItemHistory((ItemHistory) diff);
+        if (!itemState.isLastHistoryItem()) {
+            for (ItemDifference diff : orderDifferences(itemState.getEditedItem().getHistory().get(itemState.getCurrentHistoryDate()))) {
+                if (diff instanceof ItemHistory) {
+                    applyPositiveItemHistory((ItemHistory) diff);
+                }
+                if (diff instanceof ItemPositionHistoryList) {
+                    applyPositivePositionDiff((ItemPositionHistoryList) diff);
+                }
             }
-            if (diff instanceof ItemPositionHistoryList) {
-                applyPositivePositionDiff((ItemPositionHistoryList) diff);
-            }
+            itemState.setCurrentHistoryDate(itemState.getFollowingKey(itemState.getCurrentHistoryDate()));
         }
-        itemState.setCurrentHistoryDate(itemState.getFollowingKey(itemState.getCurrentHistoryDate()));
     }
 
     private void applyPositivePositionDiff(ItemPositionHistoryList diffs) {

--- a/ui/src/test/java/de/ipb_halle/lbac/items/bean/history/HistoryOperationTest.java
+++ b/ui/src/test/java/de/ipb_halle/lbac/items/bean/history/HistoryOperationTest.java
@@ -235,9 +235,9 @@ public class HistoryOperationTest {
         Date twoYearsAgo = cal.getTime();
 
         createEmptyHistory(oneYearAgo);
-        // last item in history
+        // will become last item in history
         createEmptyHistory(now);
-        // starting item in history
+        // will become starting item in history
         createEmptyHistory(twoYearsAgo);
 
         // We start with now.

--- a/ui/src/test/java/de/ipb_halle/lbac/items/bean/history/HistoryOperationTest.java
+++ b/ui/src/test/java/de/ipb_halle/lbac/items/bean/history/HistoryOperationTest.java
@@ -268,11 +268,17 @@ public class HistoryOperationTest {
         operation.applyNextNegativeDifference();
         Assert.assertEquals(twoYearsAgo, state.getChangeDate());
         Assert.assertFalse(state.isLastHistoryItem());
+        Assert.assertFalse(state.isStartingHistoryItem());
+
+        // Go to original item.
+        operation.applyNextNegativeDifference();
+        Assert.assertEquals(null, state.getChangeDate());
+        Assert.assertFalse(state.isLastHistoryItem());
         Assert.assertTrue(state.isStartingHistoryItem());
 
         // Can we go further back in time? Nope.
         operation.applyNextNegativeDifference();
-        Assert.assertEquals(twoYearsAgo, state.getChangeDate());
+        Assert.assertEquals(null, state.getChangeDate());
         Assert.assertFalse(state.isLastHistoryItem());
         Assert.assertTrue(state.isStartingHistoryItem());
     }

--- a/ui/src/test/java/de/ipb_halle/lbac/items/bean/history/HistoryOperationTest.java
+++ b/ui/src/test/java/de/ipb_halle/lbac/items/bean/history/HistoryOperationTest.java
@@ -27,8 +27,11 @@ import de.ipb_halle.lbac.items.bean.ContainerController;
 import de.ipb_halle.lbac.items.bean.ItemBean;
 import de.ipb_halle.lbac.items.bean.ItemState;
 import de.ipb_halle.lbac.project.Project;
+
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Date;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -221,6 +224,59 @@ public class HistoryOperationTest {
 
     }
 
+    @Test
+    public void test009_navigateInHistory() {
+        Calendar cal = Calendar.getInstance();
+        Date now = new Date();
+        cal.setTime(now);
+        cal.add(Calendar.YEAR, -1);
+        Date oneYearAgo = cal.getTime();
+        cal.add(Calendar.YEAR, -1);
+        Date twoYearsAgo = cal.getTime();
+
+        createEmptyHistory(oneYearAgo);
+        // last item in history
+        createEmptyHistory(now);
+        // starting item in history
+        createEmptyHistory(twoYearsAgo);
+
+        // We start with now.
+        Assert.assertEquals(now, state.getChangeDate());
+        Assert.assertTrue(state.isLastHistoryItem());
+        Assert.assertFalse(state.isStartingHistoryItem());
+
+        // Can we go further into future? Nope.
+        operation.applyNextPositiveDifference();
+        Assert.assertEquals(now, state.getChangeDate());
+        Assert.assertTrue(state.isLastHistoryItem());
+        Assert.assertFalse(state.isStartingHistoryItem());
+
+        // Go to oneYearAgo.
+        operation.applyNextNegativeDifference();
+        Assert.assertEquals(oneYearAgo, state.getChangeDate());
+        Assert.assertFalse(state.isLastHistoryItem());
+        Assert.assertFalse(state.isStartingHistoryItem());
+
+        // Back to now.
+        operation.applyNextPositiveDifference();
+        Assert.assertEquals(now, state.getChangeDate());
+        Assert.assertTrue(state.isLastHistoryItem());
+        Assert.assertFalse(state.isStartingHistoryItem());
+
+        // Go to twoYearsAgo.
+        operation.applyNextNegativeDifference();
+        operation.applyNextNegativeDifference();
+        Assert.assertEquals(twoYearsAgo, state.getChangeDate());
+        Assert.assertFalse(state.isLastHistoryItem());
+        Assert.assertTrue(state.isStartingHistoryItem());
+
+        // Can we go further back in time? Nope.
+        operation.applyNextNegativeDifference();
+        Assert.assertEquals(twoYearsAgo, state.getChangeDate());
+        Assert.assertFalse(state.isLastHistoryItem());
+        Assert.assertTrue(state.isStartingHistoryItem());
+    }
+
     private void checkForPositions(boolean[][] positions, int[] expected) {
         for (int i = 0; i < positions.length; i++) {
             for (int j = 0; j < positions.length; j++) {
@@ -239,15 +295,20 @@ public class HistoryOperationTest {
     }
 
     private ItemHistory createEmptyHistory(int day, int month, int year) {
-        ItemHistory diff1 = new ItemHistory();
-        diff1.setActor(actor);
-        diff1.setItem(item);
         Calendar cal = Calendar.getInstance();
         cal.set(year, month, day);
-        diff1.setMdate(cal.getTime());
 
-        item.getHistory().put(cal.getTime(), Arrays.asList(diff1));
-        return diff1;
+        return createEmptyHistory(cal.getTime());
+    }
+
+    private ItemHistory createEmptyHistory(Date date) {
+        ItemHistory diff = new ItemHistory();
+        diff.setActor(actor);
+        diff.setItem(item);
+        diff.setMdate(date);
+
+        item.getHistory().put(date, Arrays.asList(diff));
+        return diff;
     }
 
     private User createUser(int id, String name) {


### PR DESCRIPTION
- more history navigation tests for ItemState and HistoryOperation; also discoved and fixed missing boundary tests when moving back and forth in the history via HistoryOperation
- add getters to be used in the UI to reflect the before-first/last position in the history list (copy of ItemBean.isPreviousVersionButtonDisabled() and ItemBean.isNextVersionButtonDisabled(), which will be removed in the following UI polish)